### PR TITLE
Use the CommandBus type explicitly to get the declared methods

### DIFF
--- a/src/Commands/Merq.Commands.Tests/CommandBusSpec.cs
+++ b/src/Commands/Merq.Commands.Tests/CommandBusSpec.cs
@@ -278,5 +278,13 @@ namespace Merq
 				yield return result;
 			}
 		}
+
+		// Ensure all test to be run using a derived command bus class
+		class CommandBus : Merq.CommandBus
+		{
+			public CommandBus (IEnumerable<ICommandHandler> handlers) : base (handlers) { }
+
+			public CommandBus (params ICommandHandler[] handlers) : base (handlers) { }
+		}
 	}
 }

--- a/src/Commands/Merq.Commands/CommandBus.cs
+++ b/src/Commands/Merq.Commands/CommandBus.cs
@@ -138,9 +138,9 @@ namespace Merq
 			//
 			// commandBus.Execute (new MyCommand ()) // void command
 			// var result = commandBus.execute (new MyCommandWithResult ()) // command with result
-			
+
 			try {
-				return this.GetType ()
+				return typeof (CommandBus)
 					.GetTypeInfo ()
 					.GetDeclaredMethod (methodName)
 					.MakeGenericMethod (typeArguments)


### PR DESCRIPTION
And avoid null reference exception when the running command bus instance was created
using an inherited class (so the private inherited methods won't be found)