### PR TITLE
Remove SystemComponent behavior and double-build of VSIX

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -54,16 +54,10 @@
 	<Target Name="Package" DependsOnTargets="BuildInstaller;BuildPackages" />
 
 	<Target Name="BuildInstaller" DependsOnTargets="GitInfo">
-		<!-- Refresh the VSIX with the SystemComponent flag now for redistribution -->
-		<Message Importance="$(DefaultImportance)" Text="Refreshing VSIX with IsSystemComponent=true" />
-		<Exec Command="rmdir src\Vsix\Merq.Vsix\bin\$(Configuration) /S /Q" ContinueOnError="true" StandardOutputImportance="low" />
-		<Exec Command="rmdir src\Vsix\Merq.Vsix\obj\$(Configuration) /S /Q" ContinueOnError="true" StandardOutputImportance="low" />
-
-		<MSBuild Projects="@(Solution)" Properties="$(CommonBuildProperties);IsSystemComponent=true" />
 		<Exec Command="$(PackagesPath)\gitlink\lib\net45\GitLink.exe . -f &quot;$([System.String]::new('%(Solution.FullPath)').Replace('$(MSBuildProjectDirectory)', '').TrimStart('\').TrimStart('/'))&quot; -u https://github.com/MobileEssentials/Merq -b &quot;$(GitBranch)&quot; -c &quot;$(Configuration)&quot;" StandardOutputImportance="low" />
 
 		<MSBuild Projects="src\Installers\Merq.Installer\Merq.Installer.nuproj"
-				 Properties="$(CommonBuildProperties);IsSystemComponent=true"
+				 Properties="$(CommonBuildProperties)"
 				 Targets="Build;GetTargetPath">
 			<Output ItemName='InstallerPackage' TaskParameter='TargetOutputs' />
 		</MSBuild>

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.targets
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.targets
@@ -3,17 +3,11 @@
 	<Import Project="..\..\Merq.targets" />
 	<Import Project="Merq.Vsix.BindingRedirects.targets" />
 
-	<PropertyGroup>
-		<IsSystemComponent Condition=" '$(IsSystemComponent)' == '' ">false</IsSystemComponent>
-	</PropertyGroup>
-
 	<Target Name="GetVersion" DependsOnTargets="GitVersion" Returns="$(Version)">
 		<PropertyGroup>
 			<Version>$(GitSemVerMajor).$(GitSemVerMinor).$(GitSemVerPatch)</Version>
 		</PropertyGroup>
 	</Target>
-
-	<Target Name="GetSystemComponent" Returns="$(IsSystemComponent)" />
 
 	<Target Name="SetVsixDeploymentPath" 
 			DependsOnTargets="GetVsixDeploymentPath"


### PR DESCRIPTION
We're not using the SystemComponent flag anymore since it
makes F5 impossible, so remove that and also get rid of the
second build of the VSIX to pass that flag, since we're not
using it anymore.