### PR TITLE
Added <PackageId> to make Willow happy

### DIFF
--- a/src/Vsix/Merq.Vsix/source.extension.vsixmanifest
+++ b/src/Vsix/Merq.Vsix/source.extension.vsixmanifest
@@ -11,6 +11,7 @@
 		<Icon>Merq.ico</Icon>
 		<PreviewImage>200.png</PreviewImage>
 		<Tags>vsix</Tags>
+		<PackageId>Microsoft.VisualStudio.Xamarin.Merq</PackageId>
 	</Metadata>
 	<Installation>
 		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,12.0]" />


### PR DESCRIPTION
This is required so Willow can match this to the "package name" in the .swr where this component is defined.
Otherwise Willow will think this is a different VSIX than the one installed by vsixinstaller.exe

This shouldn't cause any pain in dev14 as it should ignore unknown elements