### PR TITLE
Don't use floating version of GitInfo/IFluentInterface

### DIFF
--- a/src/Async/Merq.Async.Core/Merq.Async.Core.Desktop/Merq.Async.Core.Desktop.csproj
+++ b/src/Async/Merq.Async.Core/Merq.Async.Core.Desktop/Merq.Async.Core.Desktop.csproj
@@ -29,7 +29,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="1.1.48" />
+    <PackageReference Include="GitInfo" Version="2.0.11" />
     <PackageReference Include="IFluentInterface" Version="2.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="14.1.114" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" />

--- a/src/Async/Merq.Async.Core/Merq.Async.Core.Portable/Merq.Async.Core.Portable.csproj
+++ b/src/Async/Merq.Async.Core/Merq.Async.Core.Portable/Merq.Async.Core.Portable.csproj
@@ -29,8 +29,8 @@
     <Compile Include="AsyncManager.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="1.1.48" />
-    <PackageReference Include="IFluentInterface" Version="2.0.3" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
+    <PackageReference Include="IFluentInterface" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="14.1.114" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" />
   </ItemGroup>

--- a/src/Async/Merq.Async.Portable.Tests/Merq.Async.Portable.Tests.csproj
+++ b/src/Async/Merq.Async.Portable.Tests/Merq.Async.Portable.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.0.0" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />

--- a/src/Async/Merq.Async.TaskScheduler/Merq.Async.TaskScheduler.csproj
+++ b/src/Async/Merq.Async.TaskScheduler/Merq.Async.TaskScheduler.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Async/Merq.Async.Tests/Merq.Async.Portable.Tests.csproj
+++ b/src/Async/Merq.Async.Tests/Merq.Async.Portable.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.0.0" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />

--- a/src/Async/Merq.Async.Tests/Merq.Async.Tests.csproj
+++ b/src/Async/Merq.Async.Tests/Merq.Async.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="3.0.0" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />

--- a/src/Async/Merq.Async/Merq.Async.csproj
+++ b/src/Async/Merq.Async/Merq.Async.csproj
@@ -9,24 +9,11 @@
   <Import Project="Merq.Async.props" />
 
   <ItemGroup>
-    <PackageReference Include="GitInfo">
-      <Version>2.*</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="IFluentInterface">
-      <Version>2.*</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project">
-      <Version>0.3.3</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Tasks">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
+    <PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="all" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
+++ b/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="Moq" Version="4.5.10" />

--- a/src/Core/Merq.Core/Merq.Core.csproj
+++ b/src/Core/Merq.Core/Merq.Core.csproj
@@ -8,8 +8,8 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.props', '$(MSBuildThisFileDirectory)'))" />
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
-    <PackageReference Include="IFluentInterface" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
+    <PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />

--- a/src/Core/Merq/Merq.csproj
+++ b/src/Core/Merq/Merq.csproj
@@ -8,24 +8,11 @@
   <Import Project="Merq.props" />
 
   <ItemGroup>
-    <PackageReference Include="GitInfo">
-      <Version>2.*</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="IFluentInterface">
-      <Version>2.*</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="MSBuilder.ThisAssembly.Project">
-      <Version>0.3.3</Version>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Runtime">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Threading.Tasks">
-      <Version>4.3.0</Version>
-    </PackageReference>
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
+    <PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="all" />
+    <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Merq.VisualStudio.proj
+++ b/src/Merq.VisualStudio.proj
@@ -60,7 +60,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuilder" Version="0.2.0" />
 		<PackageReference Include="MSBuilder.VsixDependency" Version="0.2.7" />
-		<PackageReference Include="GitInfo" Version="1.1.48" PrivateAssets="All" />
+		<PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="All" />
 		<PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="All" />
 	</ItemGroup>
 	

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.1.0" />

--- a/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
+++ b/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.0" Version="12.0.30110" />

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -92,7 +92,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
+    <PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="all" />
     <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="netfx-System.StringResources" Version="3.0.14" />


### PR DESCRIPTION
This prevents differences in behavior in GitInfo from changing
the version numbers unexpectedly. Fixed to the one used in the
last public d15-8 build