### PR TITLE
Don't use floating versions of GitInfo/MSBuilder

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -97,5 +97,5 @@
 		</ItemGroup>
 	</Target>
 	
-	<Import Project="src\Merq.targets" />
+	<Import Project="src\Directory.Build.targets" />
 </Project>

--- a/src/Async/Merq.Async.Core/Merq.Async.Core.csproj
+++ b/src/Async/Merq.Async.Core/Merq.Async.Core.csproj
@@ -49,5 +49,4 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Merq.targets))\Merq.targets" />
 </Project>

--- a/src/Async/Merq.Async.TaskScheduler/Merq.Async.TaskScheduler.csproj
+++ b/src/Async/Merq.Async.TaskScheduler/Merq.Async.TaskScheduler.csproj
@@ -20,5 +20,4 @@
     <ProjectReference Include="..\Merq.Async\Merq.Async.csproj" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Async/Merq.Async.Tests/Merq.Async.Tests.csproj
+++ b/src/Async/Merq.Async.Tests/Merq.Async.Tests.csproj
@@ -46,5 +46,4 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Async/Merq.Async/Merq.Async.csproj
+++ b/src/Async/Merq.Async/Merq.Async.csproj
@@ -33,5 +33,4 @@
     </PropertyGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Merq.targets))\Merq.targets" />
 </Project>

--- a/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
+++ b/src/Core/Merq.Core.Tests/Merq.Core.Tests.csproj
@@ -21,5 +21,4 @@
     <ProjectReference Include="..\Merq.Core\Merq.Core.csproj" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Core/Merq.Core/Merq.Core.csproj
+++ b/src/Core/Merq.Core/Merq.Core.csproj
@@ -52,5 +52,4 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Core/Merq/Merq.csproj
+++ b/src/Core/Merq/Merq.csproj
@@ -28,5 +28,4 @@
 		</PropertyGroup>
 	</Target>
 	
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Merq.targets))\Merq.targets" />
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,7 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuilder" Version="0.2.0" PrivateAssets="All" />
 		<PackageReference Include="NuGet.Build.Packaging" Version="0.2.5-dev.1" PrivateAssets="All" />
-		<PackageReference Include="GitInfo" Version="2.0.10" PrivateAssets="All" />
+		<PackageReference Include="GitInfo" Version="2.0.11" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(IncludeGlobalAssemblyInfo)' != 'false'">

--- a/src/Merq.VisualStudio.proj
+++ b/src/Merq.VisualStudio.proj
@@ -58,7 +58,7 @@
 		<PackageReference Include="NuGet.Build.Packaging" Version="*" PrivateAssets="All" />
 	</ItemGroup>
 	
-	<Import Project="Merq.targets" />
+	<Import Project="Directory.Build.targets" />
 	<Target Name="SetPackageVersion" BeforeTargets="GetPackageVersion" DependsOnTargets="GetVersion">
 		<PropertyGroup>
 			<PackageVersion>$(Version)</PackageVersion>

--- a/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
+++ b/src/Vsix/Merq.Vsix.IntegrationTests/Merq.Vsix.IntegrationTests.csproj
@@ -35,5 +35,4 @@
     </ItemGroup>
   </Target>
   
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
+++ b/src/Vsix/Merq.Vsix.Tests/Merq.Vsix.Tests.csproj
@@ -38,5 +38,4 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Merq.targets', '$(MSBuildThisFileDirectory)'))" />
 </Project>

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.csproj
@@ -92,8 +92,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.*" PrivateAssets="all" />
-    <PackageReference Include="MSBuilder" Version="*" PrivateAssets="all" />
     <PackageReference Include="MSBuilder.ThisAssembly.Project" Version="0.3.3" PrivateAssets="all" />
     <PackageReference Include="netfx-System.StringResources" Version="3.0.14" />
     <PackageReference Include="Clarius.VisualStudio" Version="2.0.12" />

--- a/src/Vsix/Merq.Vsix/Merq.Vsix.targets
+++ b/src/Vsix/Merq.Vsix/Merq.Vsix.targets
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="..\..\Merq.targets" />
 	<Import Project="Merq.Vsix.BindingRedirects.targets" />
 	<Import Project="$(VsSDKInstall)\Microsoft.VsSDK.targets" Condition="'$(VsSDKVersion)' == '' And Exists('$(VsSDKInstall)\Microsoft.VsSDK.targets')" />
 


### PR DESCRIPTION
The GitInfo one is prone to having behavior differences
across versions, even if code didn't change on our side,
so it's better to let the shared .props